### PR TITLE
refactor: update new url for anime-vsub

### DIFF
--- a/map-referer.json
+++ b/map-referer.json
@@ -1,5 +1,5 @@
 {
-  "#animevsub-vsub": "https://animevietsub.lol/",
+  "#animevsub-vsub": "https://animevietsub.id/",
   "#vuighe": "https://vuighe.net/",
   "#nettruyen": "https://www.nettruyenmax.com/",
   "#fb": "https://www.facebook.com/",


### PR DESCRIPTION
- The URL in `map-referer.json` must be updated to the latest one; otherwise, a 403 error will occur when calling the player iframe.
- Below are the images before and after the update:

<img width="1589" height="607" alt="image" src="https://github.com/user-attachments/assets/fd1acd52-7494-4031-a803-d3caeccd42e4" />
<img width="1587" height="604" alt="image" src="https://github.com/user-attachments/assets/000352a7-abc7-4ad0-95af-01f2a9e7b504" />